### PR TITLE
define char indexes as "unsigned" to make it platform-independent

### DIFF
--- a/shox96_0_2.c
+++ b/shox96_0_2.c
@@ -171,7 +171,7 @@ int shox96_0_2_compress(const char *in, int len, char *out, struct lnk_lst *prev
   byte state;
 
   int l, ll, ol;
-  char c_in, c_next, c_prev;
+  unsigned char c_in, c_next, c_prev;
   byte is_upper, is_all_upper;
 
   ol = 0;


### PR DESCRIPTION
Have a trouble during migration of my arduino project to Sloeber eclips plugin https://eclipse.baeyens.it/
Probably it have different compiler configuration and gives error
error: array subscript has type 'char'
That fixes it.