### PR TITLE
Include esp_random.h

### DIFF
--- a/esp32.c
+++ b/esp32.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <sqlite3.h>
 #include <esp_spi_flash.h>
+#include <esp_random.h>
 #include <esp_system.h>
 #include <rom/ets_sys.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Fix an issue where a compiler warning (-Wimplicit-function-declaration) causes build breaks. esp_random is used without a declaration, which causes the aforementioned warning

We have a -Werror build and we are using IDF v5, which caused a break in our build, including esp_random should fix that.

From what I understand, "esp_spi_flash" is also deprecated in favor of spi_flash_mmap in IDF v5, and I think it would be good to include "spi_flash_mmap" instead, but I left that out as I don't know if you guys would be willing for that

Thank you, and have a great day!