### PR TITLE
Compatibility check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,18 @@ Many configurations specific to SQLite library have been set in the `sdkconfig.d
 
 The Flash size has been assumed as 4MB for SPIFFS example. Please change any of these configurations if necessary.
 
+ESP-IDF Compatibility
+---------------------
+The user KikyTokamuro indicated in the `issues <https://github.com/siara-cc/esp32-idf-sqlite3/issues/18>`_ that you must do this changes for this component to work with **ESP-IDF v5.X.X**:
+
+* In the file "esp32-idf-sqlite3/CMakeLists.txt" add 'spi_flash' to REQUIRES.
+
+It was tested and work in **ESP-IDF v5.0.2-dirty** and **ESP-IDF v5.1.1-dirty**.
+
+The ESP-IDF version is handled in private_include/esp_idf_compat.h
+
+Without this changes this component should work with **ESP-IDF v4.X.X**.
+
 Issues
 ------
 

--- a/esp32.c
+++ b/esp32.c
@@ -14,12 +14,12 @@
 #include <time.h>
 #include <unistd.h>
 #include <sqlite3.h>
-#include <esp_spi_flash.h>
 #include <esp_system.h>
 #include <rom/ets_sys.h>
 #include <sys/stat.h>
 
 #include "shox96_0_2.h"
+#include "esp_idf_compat.h"
 
 #undef dbg_printf
 //#define dbg_printf(...) printf(__VA_ARGS__)

--- a/private_include/esp_idf_compat.h
+++ b/private_include/esp_idf_compat.h
@@ -1,0 +1,18 @@
+#ifndef ESP_IDF_COMPAT_H
+#define ESP_IDF_COMPAT_H
+
+#if __has_include("esp_idf_version.h")
+#include "esp_idf_version.h"
+#endif
+
+#ifdef ESP_IDF_VERSION
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+#include <esp_random.h>
+#include <spi_flash_mmap.h>
+#elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0) && ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+#include <esp_spi_flash.h>
+#endif
+
+#endif /* ESP_IDF_VERSION */
+#endif /* ESP_IDF_COMPAT_H */


### PR DESCRIPTION
The latest stable **ESP-IDF** version is `5.1.1` so reading the issues and Pull Request I added the necessary changes for the code to support both version.

#17 I took in consideration both message in the pull request

#18 I added the information provided by @KikyTokamuro in this issue
