### PR TITLE
revise(malloc): Optimizing memory allocation for esp32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ idf_component_register(SRCS "sqlite3.c" "esp32.c" "shox96_0_2.c"
                        INCLUDE_DIRS "include"
                        PRIV_INCLUDE_DIRS "private_include"
                        REQUIRES mbedtls
+                       REQUIRES spi_flash esp_partition
                        PRIV_REQUIRES console spiffs)
 
 target_compile_options(${COMPONENT_LIB} PRIVATE -std=gnu99 -g3 -fno-stack-protector -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -mlongcalls -nostdlib -Wpointer-arith -Wno-error=unused-value -Wno-error=unused-label -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=deprecated-declarations -Wno-error=char-subscripts -Wno-error=maybe-uninitialized -Wno-unused-parameter -Wno-sign-compare -Wno-old-style-declaration -MMD -c -DF_CPU=240000000L -DESP32 -DCORE_DEBUG_LEVEL=0 -DNDEBUG)

--- a/esp32.c
+++ b/esp32.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <sqlite3.h>
 #include <esp_spi_flash.h>
+#include <esp_random.h>
 #include <esp_system.h>
 #include <rom/ets_sys.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Use esp library malloc() and free() to ensure that database related operations can utilize internal memory for enhanced speed.