### PR TITLE
fix: enable recursive CTEs by undefining SQLITE_OMIT_COMPOUND_SELECT

### DIFF
--- a/config_ext.h
+++ b/config_ext.h
@@ -42,7 +42,7 @@
 #define SQLITE_OMIT_CAST                     1
 #define SQLITE_OMIT_CHECK                    1
 #define SQLITE_OMIT_COMPILEOPTION_DIAGS      1
-#define SQLITE_OMIT_COMPOUND_SELECT          1
+#undef SQLITE_OMIT_COMPOUND_SELECT
 #define SQLITE_OMIT_CONFLICT_CLAUSE          1
 #undef SQLITE_OMIT_CTE
 #define SQLITE_OMIT_DECLTYPE                 1


### PR DESCRIPTION
## Problem

Recursive CTEs (`WITH RECURSIVE ... UNION ALL`) silently fail because
`SQLITE_OMIT_COMPOUND_SELECT` is defined in `config_ext.h`. This flag
disables UNION and UNION ALL support, which is required for the UNION ALL
clause in recursive CTEs.

The CTE compiles (`sqlite3_prepare_v2` returns `SQLITE_OK`) but crashes at
runtime in `sqlite3VdbeCursorMoveto` with a `LoadProhibited` exception on
ESP32-S3, because the VDBE cursor setup is incomplete without compound
select support.

## Fix

Change line 45 in `config_ext.h`:
- Before: `#define SQLITE_OMIT_COMPOUND_SELECT          1`
- After:  `#undef SQLITE_OMIT_COMPOUND_SELECT`

## Testing

Tested on ESP32-S3-DevKitC (8MB PSRAM, ESP-IDF v5.2.3) with SQLite 3.49.1
amalgamation. Recursive CTEs now execute correctly.

Simple verification:
```sql
WITH RECURSIVE cnt(x) AS (
  SELECT 1 UNION ALL SELECT x+1 FROM cnt WHERE x < 5
) SELECT x FROM cnt;
-- Returns: 1, 2, 3, 4, 5
```

## Context

Discovered while benchmarking graph traversal queries on ESP32-S3.
Recursive CTEs are the standard SQL approach for path-finding in graphs,
and this fix enables that use case on ESP-IDF.